### PR TITLE
Fixed conflict name of System.Action - Crash.UI.Action

### DIFF
--- a/CrashEdit/MainForm.cs
+++ b/CrashEdit/MainForm.cs
@@ -3,7 +3,12 @@ using Crash.UI;
 using System;
 using System.IO;
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.Drawing;
+using System.Text;
 using System.Windows.Forms;
+
+using Actionx = Crash.UI.Action;
 
 namespace CrashEdit
 {
@@ -60,7 +65,7 @@ namespace CrashEdit
             tbiFindNext.Text = Properties.Resources.Toolbar_FindNext;
             tbiGotoEID.Text = Properties.Resources.Toolbar_GotoEID;
 
-            foreach (Crash.UI.Action action in Crash.UI.Action.AllActions)
+            foreach (Actionx action in Actionx.AllActions)
             {
                 ToolStripMenuItem tsi = new ToolStripMenuItem();
                 tsi.Tag = action;
@@ -107,7 +112,7 @@ namespace CrashEdit
                 }
                 foreach (ToolStripItem tsi in mnuEdit.DropDownItems)
                 {
-                    Crash.UI.Action action = (Crash.UI.Action)tsi.Tag;
+                    Actionx action = (Actionx)tsi.Tag;
                     if (action.CheckCompatibility(maincontrol.SelectedController))
                     {
                         tsi.Text = action.GetText(maincontrol.SelectedController);
@@ -276,7 +281,7 @@ namespace CrashEdit
         private void mniEditAction_Click(object sender,EventArgs e)
         {
             MainControl maincontrol = (MainControl)uxTabs.SelectedTab.Tag;
-            Crash.UI.Action action = (Crash.UI.Action)((ToolStripItem)sender).Tag;
+            Actionx action = (Actionx)((ToolStripItem)sender).Tag;
             Command command = action.Activate(maincontrol.SelectedController);
             if (command == null)
             {


### PR DESCRIPTION
While compile this project with xbuild with mono on Linux I find this error:

>  MainForm.cs(66,39): error CS0104: `Action' is an ambiguous reference between `Crash.UI.Action' and `System.Action'
	MainForm.cs(66,22): error CS0104: `Action' is an ambiguous reference between `Crash.UI.Action' and `System.Action'
	MainForm.cs(113,21): error CS0104: `Action' is an ambiguous reference between `Crash.UI.Action' and `System.Action'
	MainForm.cs(113,38): error CS0104: `Action' is an ambiguous reference between `Crash.UI.Action' and `System.Action'
	MainForm.cs(282,13): error CS0104: `Action' is an ambiguous reference between `Crash.UI.Action' and `System.Action'
	MainForm.cs(282,30): error CS0104: `Action' is an ambiguous reference between `Crash.UI.Action' and `System.Action'

I renamed the Action name of Crash.UI.Action to fix this error.
I don't know if exists a better solution, I never programmed in C#.